### PR TITLE
Fix upload folder

### DIFF
--- a/gts.cmd
+++ b/gts.cmd
@@ -1,0 +1,1 @@
+node node_modules/gts/build/src/cli.js %*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-iot-device-cube",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -70,9 +70,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
-      "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA==",
+      "version": "10.14.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.19.tgz",
+      "integrity": "sha512-j6Sqt38ssdMKutXBUuAcmWF8QtHW1Fwz/mz4Y+Wd9mzpBiVFirjpNQf363hG5itkG+yGaD+oiLyb50HxJ36l9Q==",
       "dev": true
     },
     "@types/serialport": {
@@ -85,9 +85,9 @@
       }
     },
     "@types/ssh2": {
-      "version": "0.5.38",
-      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.38.tgz",
-      "integrity": "sha512-rMnCnd0VIEUpCD1O5V50L1I8asHMBHZUYBnG6wlim1SdUrKUn60yiNpW5BnnT6QkTExaUXVrM8N883ZPPEPtsg==",
+      "version": "0.5.39",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.39.tgz",
+      "integrity": "sha512-MtX4tr6Jtdn/JPVsQytjB/NBeOd7JfCyf/l79KOdkUYL+r4GXUXcySX1n8W4O61fnQdljTBXEPJJ2dhnGhi2xg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -901,9 +901,9 @@
           }
         },
         "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.0.tgz",
+          "integrity": "sha512-6gpP93MR+VOOehKbCPchro3wFZNSNmek8A2kbkOAZLIZAYx1KP/zAqwO0sOHi3xJEb+UBz8NaYt/17UNit1Q9w==",
           "dev": true
         }
       }
@@ -998,9 +998,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -1018,9 +1018,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -1354,9 +1354,9 @@
       }
     },
     "cyclist": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
     "dashdash": {
@@ -1584,9 +1584,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+      "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -2130,7 +2130,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2151,12 +2152,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2171,17 +2174,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2298,7 +2304,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2310,6 +2317,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2324,6 +2332,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2331,12 +2340,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2355,6 +2366,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2435,7 +2447,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2447,6 +2460,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2532,7 +2546,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2568,6 +2583,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2587,6 +2603,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2630,12 +2647,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4278,20 +4297,20 @@
       "dev": true
     },
     "parallel-transform": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
       "dev": true,
       "requires": {
-        "cyclist": "~0.2.2",
+        "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
       }
     },
     "parse-asn1": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
       "dev": true,
       "requires": {
         "asn1.js": "^4.0.0",
@@ -4954,9 +4973,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.8.0.tgz",
-      "integrity": "sha512-3tHgtF4OzDmeKYj6V9nSyceRS0UJ3C7VqyD2Yj28vC/z2j6jG5FmFGahOKMD9CrglxTm3tETr87jEypaYV8DUg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
       "dev": true
     },
     "set-blocking": {
@@ -5428,9 +5447,9 @@
       }
     },
     "terser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.2.0.tgz",
-      "integrity": "sha512-6lPt7lZdZ/13icQJp8XasFOwZjFJkxFFIb/N1fhYEQNoNI3Ilo3KABZ9OocZvZoB39r6SiIk/0+v/bt8nZoSeA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.3.tgz",
+      "integrity": "sha512-Nzr7dpRjSzMEUS+z2UYQBtzE0LDm5k0Yy8RgLRPy85QUo1TjU5lIOBwzS5/FVAMaVyHZ3WTTU2BuQcMn8KXnNQ==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -5574,16 +5593,16 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.19.0.tgz",
-      "integrity": "sha512-1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.0.tgz",
+      "integrity": "sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
-        "diff": "^3.2.0",
+        "diff": "^4.0.1",
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
@@ -5592,14 +5611,6 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        }
       }
     },
     "tslint-config-prettier": {
@@ -5750,9 +5761,9 @@
       }
     },
     "upath": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
     },
     "update-notifier": {
@@ -5932,9 +5943,9 @@
       }
     },
     "webpack": {
-      "version": "4.39.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.2.tgz",
-      "integrity": "sha512-AKgTfz3xPSsEibH00JfZ9sHXGUwIQ6eZ9tLN8+VLzachk1Cw2LVmy+4R7ZiwTa9cZZ15tzySjeMui/UnSCAZhA==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.0.tgz",
+      "integrity": "sha512-yNV98U4r7wX1VJAj5kyMsu36T8RPPQntcb5fJLOsMz/pt/WrKC0Vp1bAlqPLkA1LegSwQwf6P+kAbyhRKVQ72g==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -5963,9 +5974,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.7.tgz",
-      "integrity": "sha512-OhTUCttAsr+IZSMVwGROGRHvT+QAs8H6/mHIl4SvhAwYywjiylYjpwybGx7WQ9Hkb45FhjtsymkwiRRbGJ1SZQ==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.9.tgz",
+      "integrity": "sha512-xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -44,16 +44,16 @@
     "@types/copy-paste": "^1.1.30",
     "@types/fs-plus": "^3.0.1",
     "@types/mocha": "^2.2.42",
-    "@types/node": "^10.14.16",
+    "@types/node": "^10.14.19",
     "@types/serialport": "^7.0.4",
-    "@types/ssh2": "^0.5.38",
+    "@types/ssh2": "^0.5.39",
     "fs-plus": "^3.1.1",
     "gts": "^1.1.0",
-    "tslint": "^5.19.0",
+    "tslint": "^5.20.0",
     "typescript": "~3.4.0",
     "vscode": "^1.1.36",
-    "webpack": "^4.39.2",
-    "webpack-cli": "^3.3.7"
+    "webpack": "^4.41.0",
+    "webpack-cli": "^3.3.9"
   },
   "dependencies": {
     "adm-zip": "^0.4.13",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ const impor = require('impor')(__dirname);
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import {PortOption} from './models/Interfaces/PortOption';
+import { PortOption } from './models/Interfaces/PortOption';
 
 const filesystem = impor(
   './models/filesystem'

--- a/src/models/Interfaces/PortListJson.ts
+++ b/src/models/Interfaces/PortListJson.ts
@@ -1,9 +1,9 @@
 export interface ComPort {
-    comName: string,
-    productId?: string,
-    vendorId?: string
+  comName: string;
+  productId?: string;
+  vendorId?: string;
 }
 
 export interface PortListJson {
-    portList: ComPort[]
+  portList: ComPort[];
 }

--- a/src/models/Interfaces/PortOption.ts
+++ b/src/models/Interfaces/PortOption.ts
@@ -1,8 +1,8 @@
 export interface PortOption {
-    baudRate?: number;
-    dataBits?: number;
-    stopBits?: number;
-    xon?: boolean;
-    xoff?: boolean;
-    parity?: string;
+  baudRate?: number;
+  dataBits?: number;
+  stopBits?: number;
+  xon?: boolean;
+  xoff?: boolean;
+  parity?: string;
 }

--- a/src/models/filesystem.ts
+++ b/src/models/filesystem.ts
@@ -12,13 +12,18 @@ export class FileSystem {
    * @param sourcePath path of folder to unzip.
    * @param targetPath path to save the generated uncompressed folder.
    */
-  static async unzipFile(sourcePath: string, targetPath: string){
+  static async unzipFile(sourcePath: string, targetPath: string) {
     return new Promise(
-      async (resolve: (value: void) => void, reject: (error: Error) => void) => {
+      async (
+        resolve: (value: void) => void,
+        reject: (error: Error) => void
+      ) => {
         try {
           // Extract archives
           const zip = new AdmZip(sourcePath);
-          const extractAllToAsyncPromisify = util.promisify(zip.extractAllToAsync);
+          const extractAllToAsyncPromisify = util.promisify(
+            zip.extractAllToAsync
+          );
           await extractAllToAsyncPromisify(targetPath, true);
         } catch (err) {
           reject(err);
@@ -30,7 +35,9 @@ export class FileSystem {
           await unlinkPromisify(sourcePath);
         } catch (err) {
           // This error does not affect folder-transfer so it does not invoke reject
-          console.log("Failed to delete compressed folder on local machine: " + err);
+          console.log(
+            'Failed to delete compressed folder on local machine: ' + err
+          );
         }
         resolve();
       }
@@ -38,7 +45,7 @@ export class FileSystem {
   }
 
   /**
-   * Get an array of volumes (path, name) on host machine. 
+   * Get an array of volumes (path, name) on host machine.
    * Sample volume: Path "C:", name "OSDisk".
    */
   static async listVolume() {

--- a/src/models/serialportctrl.ts
+++ b/src/models/serialportctrl.ts
@@ -68,6 +68,11 @@ export class SerialPortCtrl {
       monitorCallbackCommandName = (await vscode.commands.executeCommand(
         'iotworkbench.getMonitorCallbackCommandName'
       )) as string;
+      if (!monitorCallbackCommandName) {
+        throw new Error(
+          `Fail to get iot workbench monitor callback command name`
+        );
+      }
       SerialPortCtrl._port = await new SerialPort(comPort, option);
     } catch (err) {
       throw err;

--- a/src/models/serialportctrl.ts
+++ b/src/models/serialportctrl.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as os from 'os';
-import {PortOption} from './Interfaces/PortOption';
-import {ComPort, PortListJson} from './Interfaces/PortListJson';
+import { PortOption } from './Interfaces/PortOption';
+import { ComPort, PortListJson } from './Interfaces/PortListJson';
 
 const SerialPort = require('../../vendor/node-usb-native').SerialPort;
 
@@ -16,6 +16,7 @@ interface SerialPortInfo {
  * Control serialports on host machine.
  */
 export class SerialPortCtrl {
+  // tslint:disable-next-line: no-any
   private static _port: any;
 
   static getPlatform() {
@@ -32,22 +33,23 @@ export class SerialPortCtrl {
         reject: (error: Error) => void
       ) => {
         // tslint:disable-next-line: no-any
-        var portList: ComPort[] = [];
+        const portList: ComPort[] = [];
+        // tslint:disable-next-line: no-any
         SerialPort.list((err: any, ports: SerialPortInfo[]) => {
           if (err) {
             reject(err);
           } else {
-            ports.forEach( (port) => {
+            ports.forEach(port => {
               const com: ComPort = {
-                "comName": port.comName,
-                "productId": port.productId,
-                "vendorId": port.vendorId
+                comName: port.comName,
+                productId: port.productId,
+                vendorId: port.vendorId,
               };
               portList.push(com);
             });
             const portListJson = {
-              "portList": portList
-            }
+              portList,
+            };
             resolve(portListJson);
           }
         });
@@ -63,28 +65,35 @@ export class SerialPortCtrl {
   static async open(comPort: string, option: PortOption) {
     let monitorCallbackCommandName: string;
     try {
-      monitorCallbackCommandName = await vscode.commands.executeCommand(
+      monitorCallbackCommandName = (await vscode.commands.executeCommand(
         'iotworkbench.getMonitorCallbackCommandName'
-      ) as string;
+      )) as string;
       SerialPortCtrl._port = await new SerialPort(comPort, option);
     } catch (err) {
       throw err;
     }
     const errorPlaceHolder = new Error();
-    const payloadPlaceHolder = "";
+    const payloadPlaceHolder = '';
     SerialPortCtrl._port.on('open', async () => {
       try {
         await vscode.commands.executeCommand(
-          monitorCallbackCommandName, 'open', payloadPlaceHolder, errorPlaceHolder.message
+          monitorCallbackCommandName,
+          'open',
+          payloadPlaceHolder,
+          errorPlaceHolder.message
         );
       } catch (err) {
         throw err;
       }
     });
+    // tslint:disable-next-line: no-any
     SerialPortCtrl._port.on('data', async (data: any) => {
       try {
         await vscode.commands.executeCommand(
-          monitorCallbackCommandName, 'data', data.toString(), errorPlaceHolder.message
+          monitorCallbackCommandName,
+          'data',
+          data.toString(),
+          errorPlaceHolder.message
         );
       } catch (err) {
         throw err;
@@ -93,7 +102,10 @@ export class SerialPortCtrl {
     SerialPortCtrl._port.on('error', async (err: Error) => {
       try {
         vscode.commands.executeCommand(
-          monitorCallbackCommandName, 'error', payloadPlaceHolder, err.message
+          monitorCallbackCommandName,
+          'error',
+          payloadPlaceHolder,
+          err.message
         );
       } catch (err) {
         throw err;
@@ -102,14 +114,16 @@ export class SerialPortCtrl {
     SerialPortCtrl._port.on('close', async () => {
       try {
         await vscode.commands.executeCommand(
-          monitorCallbackCommandName, 'close', payloadPlaceHolder, errorPlaceHolder.message
+          monitorCallbackCommandName,
+          'close',
+          payloadPlaceHolder,
+          errorPlaceHolder.message
         );
       } catch (err) {
         throw err;
       }
     });
-    SerialPortCtrl._port.on('drain', () => {
-    });
+    SerialPortCtrl._port.on('drain', () => {});
   }
 
   /**
@@ -118,10 +132,7 @@ export class SerialPortCtrl {
    */
   static send(payload: string) {
     return new Promise(
-      (
-        resolve: (value: void) => void, 
-        reject: (reason: Error) => void
-      ) => {
+      (resolve: (value: void) => void, reject: (reason: Error) => void) => {
         try {
           // tslint:disable-next-line: no-any
           SerialPortCtrl._port.write(payload, (err: any) => {
@@ -140,12 +151,9 @@ export class SerialPortCtrl {
 
   static close() {
     return new Promise(
-      (
-        resolve: (value: void) => void,
-        reject: (value: Error) => void
-      ) => {
+      (resolve: (value: void) => void, reject: (value: Error) => void) => {
         SerialPortCtrl._port.close((err: Error) => {
-          if(err){
+          if (err) {
             reject(err);
             return;
           }
@@ -154,5 +162,4 @@ export class SerialPortCtrl {
       }
     );
   }
-  
 }

--- a/src/models/ssh.ts
+++ b/src/models/ssh.ts
@@ -207,6 +207,8 @@ export class SSH {
           }
 
           const client = SSH._getClient(id);
+
+          // Clean and create the target path if not exists.
           const cmd = `rm -rf ${targetPath} && mkdir -p ${targetPath}`;
           client.exec(cmd, (err: Error, channel: ssh2.ClientChannel) => {});
 
@@ -226,9 +228,6 @@ export class SSH {
                 localFolderPath.length
               );
               let remoteFolderPath = path.join(targetPath, relativePath);
-              console.log(
-                `### local file ${filePath} will be transfer to remote path ${remoteFolderPath}`
-              );
 
               remoteFolderPath = remoteFolderPath
                 .replace(/[\/\\]+/g, '/')


### PR DESCRIPTION
Bug: Original version use `uploadFile` API to implement `uploadFolder` API, which will create one stfp channel  per file. stfp has channel limit. `uploadFolder` will fail when folder contians a quantity of files.
https://github.com/mscdex/ssh2/issues/629#issuecomment-341235658

Fix: When upload a folder, create one sftp connection channel and reuse the channel, using `fastPut()` to upload files inside the folder. Use `sftp.end()` when all files are uploaded to close the channel.